### PR TITLE
Python fido2 patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ firmware-*.json
 *.sha2
 *.hex
 
+*.pyc
+.tags*

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -103,7 +103,10 @@ solo_cli.add_command(mergehex)
 
 
 @click.command()
-def ls():
+@click.option(
+    "-a", "--all", is_flag=True, default=False, help="Show ST DFU devices too."
+)
+def ls(all):
     """List Solos (in firmware or bootloader mode) and potential Solos in dfu mode."""
 
     solos = solo.client.find_all()
@@ -115,18 +118,21 @@ def ls():
         else:
             print(f"{descriptor['path']}: {descriptor['product_string']}")
 
-    print(":: Potential Solos in DFU mode")
-    try:
-        st_dfus = solo.dfu.find_all()
-        for d in st_dfus:
-            dev_raw = d.dev
-            dfu_serial = dev_raw.serial_number
-            print(f"{dfu_serial}")
-    except usb.core.NoBackendError:
-        print("No libusb available.")
-        print("This error is only relevant if you plan to use the ST DFU interface.")
-        print("If you are on Windows, please install a driver:")
-        print("https://github.com/libusb/libusb/wiki/Windows#driver-installation")
+    if all:
+        print(":: Potential Solos in DFU mode")
+        try:
+            st_dfus = solo.dfu.find_all()
+            for d in st_dfus:
+                dev_raw = d.dev
+                dfu_serial = dev_raw.serial_number
+                print(f"{dfu_serial}")
+        except usb.core.NoBackendError:
+            print("No libusb available.")
+            print(
+                "This error is only relevant if you plan to use the ST DFU interface."
+            )
+            print("If you are on Windows, please install a driver:")
+            print("https://github.com/libusb/libusb/wiki/Windows#driver-installation")
 
 
 solo_cli.add_command(ls)

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -110,7 +110,10 @@ def ls():
     print(":: Solos")
     for c in solos:
         descriptor = c.dev.descriptor
-        print(f"{descriptor['path']}: {descriptor['product_string']}")
+        if "serial_number" in descriptor:
+            print(f"{descriptor['serial_number']}: {descriptor['product_string']}")
+        else:
+            print(f"{descriptor['path']}: {descriptor['product_string']}")
 
     print(":: Potential Solos in DFU mode")
     try:

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -17,6 +17,7 @@ import solo.operations
 from solo.cli.key import key
 from solo.cli.monitor import monitor
 from solo.cli.program import program
+from . import _patches
 
 
 @click.group()

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -17,7 +17,7 @@ import solo.operations
 from solo.cli.key import key
 from solo.cli.monitor import monitor
 from solo.cli.program import program
-from . import _patches
+from . import _patches  # noqa  (since otherwise "unused")
 
 
 @click.group()

--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -1,0 +1,97 @@
+# Monkey patch FIDO2 backend to get serial number
+## windows
+import fido2._pyu2f.windows
+
+oldDevAttrFunc = fido2._pyu2f.windows.FillDeviceAttributes
+from ctypes import wintypes
+import ctypes
+
+fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.restype = wintypes.BOOLEAN
+fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_ulong,
+]
+
+
+def newDevAttrFunc(device, descriptor):
+    oldDevAttrFunc(device, descriptor)
+    buf_ser = ctypes.create_string_buffer(1024)
+    result = fido2._pyu2f.windows.hid.HidD_GetSerialNumberString(device, buf_ser, 1024)
+    if result:
+        descriptor.serial_number = ctypes.wstring_at(buf_ser)
+
+
+fido2._pyu2f.windows.FillDeviceAttributes = newDevAttrFunc
+
+
+## MacOS
+import fido2._pyu2f.macos
+from fido2._pyu2f import base
+from fido2._pyu2f.macos import *
+
+HID_DEVICE_PROPERTY_SERIAL_NUMBER = b"SerialNumber"
+
+
+def newEnumerate():
+    """See base class."""
+    # Init a HID manager
+    hid_mgr = iokit.IOHIDManagerCreate(None, None)
+    if not hid_mgr:
+        raise OSError("Unable to obtain HID manager reference")
+    iokit.IOHIDManagerSetDeviceMatching(hid_mgr, None)
+
+    # Get devices from HID manager
+    device_set_ref = iokit.IOHIDManagerCopyDevices(hid_mgr)
+    if not device_set_ref:
+        raise OSError("Failed to obtain devices from HID manager")
+
+    num = iokit.CFSetGetCount(device_set_ref)
+    devices = (IO_HID_DEVICE_REF * num)()
+    iokit.CFSetGetValues(device_set_ref, devices)
+
+    # Retrieve and build descriptor dictionaries for each device
+    descriptors = []
+    for dev in devices:
+        d = base.DeviceDescriptor()
+        d.vendor_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_VENDOR_ID)
+        d.product_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRODUCT_ID)
+        d.product_string = GetDeviceStringProperty(dev, HID_DEVICE_PROPERTY_PRODUCT)
+        d.serial_number = GetDeviceStringProperty(
+            dev, HID_DEVICE_PROPERTY_SERIAL_NUMBER
+        )
+        d.usage = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE)
+        d.usage_page = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE)
+        d.report_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_REPORT_ID)
+        d.path = GetDevicePath(dev)
+        descriptors.append(d.ToPublicDict())
+
+    # Clean up CF objects
+    cf.CFRelease(device_set_ref)
+    cf.CFRelease(hid_mgr)
+
+    return descriptors
+
+
+fido2._pyu2f.macos.MacOsHidDevice.Enumerate = newEnumerate
+
+
+## Linux
+import fido2._pyu2f.linux
+
+oldnewParseUevent = fido2._pyu2f.linux.ParseUevent
+
+
+def newParseUevent(uevent, desc):
+    oldnewParseUevent(uevent, desc)
+    lines = uevent.split(b"\n")
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        k, v = line.split(b"=")
+        if k == b"HID_UNIQ":
+            desc.serial_number = v.decode("utf8")
+
+
+fido2._pyu2f.linux.ParseUevent = newParseUevent

--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -1,4 +1,5 @@
 # Monkey patch FIDO2 backend to get serial number
+
 ## windows
 import fido2._pyu2f.windows
 

--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -1,98 +1,103 @@
 # Monkey patch FIDO2 backend to get serial number
 
-## windows
-import fido2._pyu2f.windows
+import sys
 
-oldDevAttrFunc = fido2._pyu2f.windows.FillDeviceAttributes
-from ctypes import wintypes
-import ctypes
+## Windows
+if sys.platform.startswith('win32'):
+    import fido2._pyu2f.windows
 
-fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.restype = wintypes.BOOLEAN
-fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.argtypes = [
-    ctypes.c_void_p,
-    ctypes.c_void_p,
-    ctypes.c_ulong,
-]
+    oldDevAttrFunc = fido2._pyu2f.windows.FillDeviceAttributes
+    from ctypes import wintypes
+    import ctypes
 
-
-def newDevAttrFunc(device, descriptor):
-    oldDevAttrFunc(device, descriptor)
-    buf_ser = ctypes.create_string_buffer(1024)
-    result = fido2._pyu2f.windows.hid.HidD_GetSerialNumberString(device, buf_ser, 1024)
-    if result:
-        descriptor.serial_number = ctypes.wstring_at(buf_ser)
+    fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.restype = wintypes.BOOLEAN
+    fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+    ]
 
 
-fido2._pyu2f.windows.FillDeviceAttributes = newDevAttrFunc
+    def newDevAttrFunc(device, descriptor):
+        oldDevAttrFunc(device, descriptor)
+        buf_ser = ctypes.create_string_buffer(1024)
+        result = fido2._pyu2f.windows.hid.HidD_GetSerialNumberString(device, buf_ser, 1024)
+        if result:
+            descriptor.serial_number = ctypes.wstring_at(buf_ser)
 
 
-## MacOS
-import fido2._pyu2f.macos
-from fido2._pyu2f import base
-from fido2._pyu2f.macos import *
-
-HID_DEVICE_PROPERTY_SERIAL_NUMBER = b"SerialNumber"
+    fido2._pyu2f.windows.FillDeviceAttributes = newDevAttrFunc
 
 
-def newEnumerate():
-    """See base class."""
-    # Init a HID manager
-    hid_mgr = iokit.IOHIDManagerCreate(None, None)
-    if not hid_mgr:
-        raise OSError("Unable to obtain HID manager reference")
-    iokit.IOHIDManagerSetDeviceMatching(hid_mgr, None)
+## macOS
+if sys.platform.startswith('darwin'):
+    import fido2._pyu2f.macos
+    from fido2._pyu2f import base
+    from fido2._pyu2f.macos import *
 
-    # Get devices from HID manager
-    device_set_ref = iokit.IOHIDManagerCopyDevices(hid_mgr)
-    if not device_set_ref:
-        raise OSError("Failed to obtain devices from HID manager")
-
-    num = iokit.CFSetGetCount(device_set_ref)
-    devices = (IO_HID_DEVICE_REF * num)()
-    iokit.CFSetGetValues(device_set_ref, devices)
-
-    # Retrieve and build descriptor dictionaries for each device
-    descriptors = []
-    for dev in devices:
-        d = base.DeviceDescriptor()
-        d.vendor_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_VENDOR_ID)
-        d.product_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRODUCT_ID)
-        d.product_string = GetDeviceStringProperty(dev, HID_DEVICE_PROPERTY_PRODUCT)
-        d.serial_number = GetDeviceStringProperty(
-            dev, HID_DEVICE_PROPERTY_SERIAL_NUMBER
-        )
-        d.usage = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE)
-        d.usage_page = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE)
-        d.report_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_REPORT_ID)
-        d.path = GetDevicePath(dev)
-        descriptors.append(d.ToPublicDict())
-
-    # Clean up CF objects
-    cf.CFRelease(device_set_ref)
-    cf.CFRelease(hid_mgr)
-
-    return descriptors
+    HID_DEVICE_PROPERTY_SERIAL_NUMBER = b"SerialNumber"
 
 
-fido2._pyu2f.macos.MacOsHidDevice.Enumerate = newEnumerate
+    def newEnumerate():
+        """See base class."""
+        # Init a HID manager
+        hid_mgr = iokit.IOHIDManagerCreate(None, None)
+        if not hid_mgr:
+            raise OSError("Unable to obtain HID manager reference")
+        iokit.IOHIDManagerSetDeviceMatching(hid_mgr, None)
+
+        # Get devices from HID manager
+        device_set_ref = iokit.IOHIDManagerCopyDevices(hid_mgr)
+        if not device_set_ref:
+            raise OSError("Failed to obtain devices from HID manager")
+
+        num = iokit.CFSetGetCount(device_set_ref)
+        devices = (IO_HID_DEVICE_REF * num)()
+        iokit.CFSetGetValues(device_set_ref, devices)
+
+        # Retrieve and build descriptor dictionaries for each device
+        descriptors = []
+        for dev in devices:
+            d = base.DeviceDescriptor()
+            d.vendor_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_VENDOR_ID)
+            d.product_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRODUCT_ID)
+            d.product_string = GetDeviceStringProperty(dev, HID_DEVICE_PROPERTY_PRODUCT)
+            d.serial_number = GetDeviceStringProperty(
+                dev, HID_DEVICE_PROPERTY_SERIAL_NUMBER
+            )
+            d.usage = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE)
+            d.usage_page = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE)
+            d.report_id = GetDeviceIntProperty(dev, HID_DEVICE_PROPERTY_REPORT_ID)
+            d.path = GetDevicePath(dev)
+            descriptors.append(d.ToPublicDict())
+
+        # Clean up CF objects
+        cf.CFRelease(device_set_ref)
+        cf.CFRelease(hid_mgr)
+
+        return descriptors
+
+
+    fido2._pyu2f.macos.MacOsHidDevice.Enumerate = newEnumerate
 
 
 ## Linux
-import fido2._pyu2f.linux
+if sys.platform.startswith('linux'):
+    import fido2._pyu2f.linux
 
-oldnewParseUevent = fido2._pyu2f.linux.ParseUevent
-
-
-def newParseUevent(uevent, desc):
-    oldnewParseUevent(uevent, desc)
-    lines = uevent.split(b"\n")
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-        k, v = line.split(b"=")
-        if k == b"HID_UNIQ":
-            desc.serial_number = v.decode("utf8")
+    oldnewParseUevent = fido2._pyu2f.linux.ParseUevent
 
 
-fido2._pyu2f.linux.ParseUevent = newParseUevent
+    def newParseUevent(uevent, desc):
+        oldnewParseUevent(uevent, desc)
+        lines = uevent.split(b"\n")
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            k, v = line.split(b"=")
+            if k == b"HID_UNIQ":
+                desc.serial_number = v.decode("utf8")
+
+
+    fido2._pyu2f.linux.ParseUevent = newParseUevent

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -33,42 +33,46 @@ def rng():
 
 @click.command()
 @click.option("--count", default=8, help="How many bytes to generate (defaults to 8)")
-def hexbytes(count):
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def hexbytes(count, serial):
     """Output COUNT number of random bytes, hex-encoded."""
     if not 0 <= count <= 255:
         print(f"Number of bytes must be between 0 and 255, you passed {count}")
         sys.exit(1)
 
-    print(solo.client.find().get_rng(count).hex())
+    print(solo.client.find(serial).get_rng(count).hex())
 
 
 @click.command()
-def raw():
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def raw(serial):
     """Output raw entropy endlessly."""
-    p = solo.client.find()
+    p = solo.client.find(serial)
     while True:
         r = p.get_rng(255)
         sys.stdout.buffer.write(r)
 
 
 @click.command()
-def reset():
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def reset(serial):
     """Reset key - wipes all credentials!!!"""
     if click.confirm(
         "Warning: Your credentials will be lost!!! Do you wish to continue?"
     ):
         print("Press the button to confirm -- again, your credentials will be lost!!!")
-        solo.client.find().reset()
+        solo.client.find(serial).reset()
         click.echo("....aaaand they're gone")
 
 
 @click.command()
-def verify():
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def verify(serial):
     """Verify key is valid Solo Secure or Solo Hacker."""
     # Any longer and this needs to go in a submodule
     print("Please press the button on your Solo key")
     try:
-        cert = solo.client.find().make_credential()
+        cert = solo.client.find(serial).make_credential()
     except Fido2ClientError:
         print("Error getting credential, is your key in bootloader mode?")
         print("Try: `solo program aux leave-bootloader`")
@@ -86,10 +90,11 @@ def verify():
 
 
 @click.command()
-def version():
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def version(serial):
     """Version of firmware on key."""
     try:
-        major, minor, patch = solo.client.find().solo_version()
+        major, minor, patch = solo.client.find(serial).solo_version()
         print(f"{major}.{minor}.{patch}")
     except solo.exceptions.NoSoloFoundError:
         print("No Solo found.")
@@ -100,9 +105,10 @@ def version():
 
 
 @click.command()
-def wink():
+@click.option("-s", "--serial", help="Serial number of Solo to wink")
+def wink(serial):
     """Send wink command to key (blinks LED a few times)."""
-    solo.client.find().wink()
+    solo.client.find(serial).wink()
 
 
 key.add_command(rng)

--- a/solo/cli/update.py
+++ b/solo/cli/update.py
@@ -49,7 +49,8 @@ def update(serial, hacker, secure, local_firmware_server):
 
     # Determine target key
     try:
-        solo_client = solo.client.find(solo_serial=serial)
+        solo_client = solo.client.find(serial)
+
     except solo.exceptions.NoSoloFoundError:
         print()
         print("No Solo key found!")
@@ -62,6 +63,7 @@ def update(serial, hacker, secure, local_firmware_server):
         print("For more, see https://docs.solokeys.io/solo/udev/")
         print()
         sys.exit(1)
+
     except solo.exceptions.NonUniqueDeviceError:
         print()
         print("Multiple Solo keys are plugged in! Please:")
@@ -70,6 +72,7 @@ def update(serial, hacker, secure, local_firmware_server):
         print("  * unplug all but one key")
         print()
         sys.exit(1)
+
     except Exception:
         print()
         print("Unhandled error connecting to key.")

--- a/solo/client.py
+++ b/solo/client.py
@@ -30,7 +30,7 @@ import solo.exceptions
 from solo import helpers
 
 
-def find(retries=5, raw_device=None, solo_serial=None):
+def find(solo_serial=None, retries=5, raw_device=None):
     # TODO: change `p` (for programmer) throughout
     p = SoloClient()
 
@@ -89,12 +89,12 @@ class SoloClient:
             pass
 
     def find_device(self, dev=None, solo_serial=None):
-        if solo_serial is not None:
-            # need to find a way to determine serial number in USB info
-            # maybe via usb.util.get_string(dev, dev.iSerialNumber)
-            raise NotImplementedError
         if dev is None:
             devices = list(CtapHidDevice.list_devices())
+            if solo_serial is not None:
+                devices = [
+                    d for d in devices if d.descriptor["serial_number"] == solo_serial
+                ]
             if len(devices) > 1:
                 raise solo.exceptions.NonUniqueDeviceError
             if len(devices) == 0:


### PR DESCRIPTION
This hot-fixes the FIDO2 backed to additionally read the serial number for the device descriptor object.

Tested only on Windows, still needs to be tested on Linux and MacOS.