### PR TITLE
Fix bootloader version mapping single-value version

### DIFF
--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -282,7 +282,11 @@ aux.add_command(reboot)
 def bootloader_version(serial):
     """Version of bootloader."""
     p = solo.client.find(serial)
-    print(".".join(map(str, p.bootloader_version())))
+    version = p.bootloader_version()
+    if type(version) == list:
+        print(".".join(map(str, version)))
+    else:
+        print(version)
 
 
 aux.add_command(bootloader_version)


### PR DESCRIPTION
Running `solo program aux bootloader-version` currently results in this exception:
```
Traceback (most recent call last):
  File "/usr/bin/solo", line 10, in <module>
    sys.exit(solo_cli())
  File "/usr/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/solo/cli/program.py", line 278, in bootloader_version
    print(".".join(map(str, p.bootloader_version())))
TypeError: 'int' object is not iterable
```
because [`solo.client.bootloader_version`](https://github.com/solokeys/solo-python/blob/master/solo/client.py#L188) can return a single integer value.