### PR TITLE
Auto switch

### DIFF
--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -14,6 +14,7 @@ import click
 from fido2.ctap import CtapError
 
 import solo
+from solo.helpers import enter_bootloader_or_die
 
 
 @click.group()
@@ -157,7 +158,23 @@ def bootloader(serial, firmware):
     """
 
     p = solo.client.find(serial)
-    p.program_file(firmware)
+    try:
+        p.program_file(firmware)
+    except CtapError as e:
+        if e.code == CtapError.ERR.INVALID_COMMAND:
+            print("Not in bootloader mode.  Attempting to switch...")
+        else:
+            raise e
+
+        enter_bootloader_or_die(p)
+
+        print("Solo rebooted.  Reconnecting...")
+        time.sleep(0.5)
+        p = solo.client.find(serial)
+        if p is None:
+            print("Cannot find Solo device.")
+            return -1
+        p.program_file(firmware)
 
 
 program.add_command(bootloader)
@@ -183,18 +200,8 @@ def enter_bootloader(serial):
 
     p = solo.client.find(serial)
 
-    try:
-        p.enter_solo_bootloader()
-    # except OSError:
-    #     pass
-    except CtapError as e:
-        if e.code == CtapError.ERR.INVALID_COMMAND:
-            print(
-                "Solo appears to not be a solo hacker.  Try holding down the button for 2 while you plug token in."
-            )
-            sys.exit(1)
-        else:
-            raise (e)
+    enter_bootloader_or_die(p)
+
     print("Solo rebooted.  Reconnecting...")
     time.sleep(0.5)
     if solo.client.find(serial) is None:

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -159,6 +159,7 @@ def bootloader(serial, firmware):
 
     p = solo.client.find(serial)
     try:
+        p.use_hid()
         p.program_file(firmware)
     except CtapError as e:
         if e.code == CtapError.ERR.INVALID_COMMAND:
@@ -174,6 +175,7 @@ def bootloader(serial, firmware):
         if p is None:
             print("Cannot find Solo device.")
             return -1
+        p.use_hid()
         p.program_file(firmware)
 
 

--- a/solo/client.py
+++ b/solo/client.py
@@ -139,10 +139,7 @@ class SoloClient:
 
         ret = data[0]
         if ret != CtapError.ERR.SUCCESS:
-            str = ""
-            if ret == CtapError.ERR.NOT_ALLOWED:
-                str = "Out of bounds write"
-            raise RuntimeError("Device returned non-success code %02x: %s" % (ret, str))
+            raise CtapError(ret)
 
         return data[1:]
 
@@ -156,10 +153,7 @@ class SoloClient:
 
         ret = res.signature[0]
         if ret != CtapError.ERR.SUCCESS:
-            str = ""
-            if ret == CtapError.ERR.NOT_ALLOWED:
-                str = "Out of bounds write"
-            raise RuntimeError("Device returned non-success code %02x: %s" % (ret, str))
+            raise CtapError(ret)
 
         return res.signature[1:]
 

--- a/solo/helpers.py
+++ b/solo/helpers.py
@@ -19,3 +19,18 @@ def from_websafe(data):
     data = data.replace("-", "+")
     data = data.replace("_", "/")
     return data + "=="[: (3 * len(data)) % 4]
+
+
+def enter_bootloader_or_die(p):
+    try:
+        p.enter_solo_bootloader()
+    # except OSError:
+    #     pass
+    except CtapError as e:
+        if e.code == CtapError.ERR.INVALID_COMMAND:
+            print(
+                "Solo appears to not be a solo hacker.  Try holding down the button for 2 while you plug token in."
+            )
+            sys.exit(1)
+        else:
+            raise (e)


### PR DESCRIPTION
When programming, `solo program bootloader solo.hex`, make it auto-switch to bootloader mode if needed.  This makes it a lot more convenient when developing.

Also default to `hid` transport for extension messages, rather than `u2f`, since it's about 30% faster.