### PR TITLE
rewrite option bytes on detach if needed

### DIFF
--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -262,35 +262,10 @@ def leave_dfu(serial):
 
     """
 
-    dfu = solo.dfu.find(serial, altsetting=1)  # select option bytes
+    dfu = solo.dfu.find(serial)  # select option bytes
     dfu.init()
 
-    ptr = 0x1FFF7800  # option byte address for STM32l432
-    dfu.set_addr(ptr)
-
-    while dfu.state() == DFU.state.DOWNLOAD_BUSY:
-        pass
-    m = dfu.read_mem(0, 16)
-
-    op = struct.unpack("<L", m[:4])[0]
-    oldop = op
-
-    op |= 1 << 27  #  nBOOT0 = 1  (boot from main mem)
-    op &= ~(1 << 26)  # nSWBOOT0 = 0  (boot from nBoot0)
-
-    if oldop != op:
-        print("Rewriting option bytes...")
-        m = struct.pack("<L", op) + m[4:]
-
-        while dfu.state() == DFU.state.DOWNLOAD_BUSY:
-            print(dfu.state())
-
-        m = dfu.write_page(0, m)
-
-        while dfu.state() == DFU.state.DOWNLOAD_BUSY:
-            pass
-
-    dfu.detach()
+    dfu.prepare_options_bytes_detach()
 
     print("Please powercycle the device (pull out, plug in again)")
 

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -15,6 +15,9 @@ import click
 from fido2.ctap import CtapError
 
 import solo
+from solo.commands import DFU
+from solo.dfu import hot_patch_windows_libusb
+from solo.helpers import enter_bootloader_or_die
 
 
 @click.group()
@@ -131,6 +134,8 @@ def dfu(serial, connect_attempts, detach, dry_run, firmware):
 
     if detach:
         dfu.detach()
+
+    hot_patch_windows_libusb()
 
 
 program.add_command(dfu)
@@ -264,9 +269,10 @@ def leave_dfu(serial):
 
     dfu = solo.dfu.find(serial)  # select option bytes
     dfu.init()
-
     dfu.prepare_options_bytes_detach()
+    dfu.detach()
 
+    hot_patch_windows_libusb()
     print("Please powercycle the device (pull out, plug in again)")
 
 

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -265,6 +265,9 @@ def leave_dfu(serial):
     dfu = solo.dfu.find(serial, altsetting=1)  # select option bytes
     dfu.init()
 
+    ptr = 0x1FFF7800  # option byte address for STM32l432
+    dfu.set_addr(ptr)
+
     while dfu.state() == DFU.state.DOWNLOAD_BUSY:
         pass
     m = dfu.read_mem(0, 16)

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -9,7 +9,6 @@
 
 import sys
 import time
-import struct
 
 import usb
 
@@ -17,9 +16,7 @@ import click
 from fido2.ctap import CtapError
 
 import solo
-from solo.commands import DFU
 from solo.dfu import hot_patch_windows_libusb
-from solo.helpers import enter_bootloader_or_die
 
 
 @click.group()

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -132,7 +132,9 @@ def dfu(serial, connect_attempts, detach, dry_run, firmware):
         print("firmware readback verified.")
 
     if detach:
+        dfu.prepare_options_bytes_detach()
         dfu.detach()
+        print("Please powercycle the device (pull out, plug in again)")
 
     hot_patch_windows_libusb()
 

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -11,6 +11,8 @@ import sys
 import time
 import struct
 
+import usb
+
 import click
 from fido2.ctap import CtapError
 
@@ -270,7 +272,10 @@ def leave_dfu(serial):
     dfu = solo.dfu.find(serial)  # select option bytes
     dfu.init()
     dfu.prepare_options_bytes_detach()
-    dfu.detach()
+    try:
+        dfu.detach()
+    except usb.core.USBError:
+        pass
 
     hot_patch_windows_libusb()
     print("Please powercycle the device (pull out, plug in again)")

--- a/solo/commands.py
+++ b/solo/commands.py
@@ -8,6 +8,12 @@
 # copied, modified, or distributed except according to those terms.
 
 
+class STM32L4:
+    class options:
+        nBOOT0 = 1 << 27
+        nSWBOOT0 = 1 << 26
+
+
 class SoloExtension:
     version = 0x14
     rng = 0x15

--- a/solo/dfu.py
+++ b/solo/dfu.py
@@ -7,7 +7,8 @@
 # http://opensource.org/licenses/MIT>, at your option. This file may not be
 # copied, modified, or distributed except according to those terms.
 
-import time, struct
+import struct
+import time
 
 import usb.core
 import usb.util
@@ -225,7 +226,7 @@ class DFUDevice:
         try:
             m = self.write_page(0, m)
             self.block_on_state(DFU.state.DOWNLOAD_BUSY)
-        except OSError as e:
+        except OSError:
             print("Warning: OSError with write_page")
 
     def prepare_options_bytes_detach(self,):

--- a/solo/dfu.py
+++ b/solo/dfu.py
@@ -30,7 +30,7 @@ def newdel(self):
 usb._objfinalizer._AutoFinalizedObjectBase.__del__ = newdel
 
 
-def find(dfu_serial=None, attempts=8, raw_device=None):
+def find(dfu_serial=None, attempts=8, raw_device=None, altsetting=1):
     """dfu_serial is the ST bootloader serial number.
 
     It is not directly the ST chip identifier, but related via
@@ -39,7 +39,7 @@ def find(dfu_serial=None, attempts=8, raw_device=None):
     for i in range(attempts):
         dfu = DFUDevice()
         try:
-            dfu.find(ser=dfu_serial, dev=raw_device)
+            dfu.find(ser=dfu_serial, dev=raw_device, altsetting=altsetting)
             return dfu
         except RuntimeError:
             time.sleep(0.25)
@@ -115,6 +115,18 @@ class DFUDevice:
                     return self.dev
 
         raise RuntimeError("No ST DFU alternate-%d found." % altsetting)
+
+    # Main memory == 0
+    # option bytes == 1
+    def set_alt(self, alt):
+        for cfg in self.dev:
+            for intf in cfg:
+                # print(intf, intf.bAlternateSetting)
+                if intf.bAlternateSetting == alt:
+                    intf.set_altsetting()
+                    self.intf = intf
+                    self.intNum = intf.bInterfaceNumber
+                    # return self.dev
 
     def init(self,):
         if self.state() == DFU.state.ERROR:

--- a/solo/dfu.py
+++ b/solo/dfu.py
@@ -215,17 +215,26 @@ class DFUDevice:
 
     def read_option_bytes(self,):
         ptr = 0x1FFF7800  # option byte address for STM32l432
-        # self.set_addr(ptr)
+        self.set_addr(ptr)
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
         m = self.read_mem(0, 16)
         return m
 
     def write_option_bytes(self, m):
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
-        m = self.write_page(0, m)
-        self.block_on_state(DFU.state.DOWNLOAD_BUSY)
+        try:
+            m = self.write_page(0, m)
+            self.block_on_state(DFU.state.DOWNLOAD_BUSY)
+        except OSError as e:
+            print("Warning: OSError with write_page")
 
     def prepare_options_bytes_detach(self,):
+
+        # Necessary to prevent future errors...
+        m = self.read_mem(0, 16)
+        self.write_option_bytes(m)
+        #
+
         m = self.read_option_bytes()
         op = struct.unpack("<L", m[:4])[0]
         oldop = op


### PR DESCRIPTION
Sometimes Solo can get stuck in the DFU unless the option bytes get re-written.  Previously just the detach command was used, and the solo firmware would adjust the option bytes on boot, but it seems the detach command isn't reliable.

Now prior to detach-dfu, the option bytes are checked and adjusted if needed.