### PR TITLE
Feed Solo entropy to Linux kernel

### DIFF
--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -22,14 +22,15 @@ from solo.cli.program import program
 from . import _patches  # noqa  (since otherwise "unused")
 
 
-if (os.name == "posix" and os.geteuid() == 0):
-    print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
-    print()
-    print("Please install udev rules and run `solo` as regular user (without sudo).")
-    print("We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules")
-    print()
-    print("For more information, see: https://docs.solokeys.io/solo/udev/")
-    sys.exit(1)
+if (os.name == "posix") and os.environ.get("ALLOW_ROOT") is None:
+    if os.geteuid() == 0:
+        print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
+        print()
+        print("Please install udev rules and run `solo` as regular user (without sudo).")
+        print("We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules")
+        print()
+        print("For more information, see: https://docs.solokeys.io/solo/udev/")
+        sys.exit(1)
 
 
 @click.group()

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -26,8 +26,12 @@ if (os.name == "posix") and os.environ.get("ALLOW_ROOT") is None:
     if os.geteuid() == 0:
         print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
         print()
-        print("Please install udev rules and run `solo` as regular user (without sudo).")
-        print("We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules")
+        print(
+            "Please install udev rules and run `solo` as regular user (without sudo)."
+        )
+        print(
+            "We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules"
+        )
         print()
         print("For more information, see: https://docs.solokeys.io/solo/udev/")
         sys.exit(1)

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -54,6 +54,7 @@ def raw(serial):
         r = p.get_rng(255)
         sys.stdout.buffer.write(r)
 
+
 @click.command()
 @click.option("--count", default=64, help="How many bytes to generate (defaults to 8)")
 @click.option("-s", "--serial", help="Serial number of Solo to use")
@@ -72,6 +73,7 @@ def feedkernel(count, serial):
 
     import struct
     import fcntl
+
     RNDADDENTROPY = 0x40085203
 
     entropy_info_file = "/proc/sys/kernel/random/entropy_avail"
@@ -98,15 +100,10 @@ def feedkernel(count, serial):
     #       added to the entropy pool.
 
     entropy_bits_per_byte = 2  # maximum 8, tend to be pessimistic
-    t = struct.pack(
-        f"ii{count}s",
-        count * entropy_bits_per_byte,
-        count,
-        r,
-    )
+    t = struct.pack(f"ii{count}s", count * entropy_bits_per_byte, count, r)
 
-    with open("/dev/random", mode='wb') as fh:
-        res = fcntl.ioctl(fh, RNDADDENTROPY, t)
+    with open("/dev/random", mode="wb") as fh:
+        _ = fcntl.ioctl(fh, RNDADDENTROPY, t)
     print(f"Entropy after:  0x{open(entropy_info_file).read().strip()}")
 
 
@@ -148,13 +145,18 @@ def probe(serial, udp, hash_type, filename):
         print(f"content from hex: {bytes.fromhex(result_hex[128:])}")
         print(f"signature: {result[:128]}")
         import nacl.signing
+
         # verify_key = nacl.signing.VerifyKey(bytes.fromhex("c69995185efa20bf7a88139f5920335aa3d3e7f20464345a2c095c766dfa157a"))
-        verify_key = nacl.signing.VerifyKey(bytes.fromhex("c69995185efa20bf7a88139f5920335aa3d3e7f20464345a2c095c766dfa157a"))
+        verify_key = nacl.signing.VerifyKey(
+            bytes.fromhex(
+                "c69995185efa20bf7a88139f5920335aa3d3e7f20464345a2c095c766dfa157a"
+            )
+        )
         try:
-           message = verify_key.verify(result)
-           verified = True
+            _ = verify_key.verify(result)
+            verified = True
         except nacl.exceptions.BadSignatureError:
-           verified = False
+            verified = False
         print(f"verified? {verified}")
     # print(fido2.cbor.loads(result))
 

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -55,12 +55,17 @@ def raw(serial):
         sys.stdout.buffer.write(r)
 
 @click.command()
+@click.option("--count", default=64, help="How many bytes to generate (defaults to 8)")
 @click.option("-s", "--serial", help="Serial number of Solo to use")
-def feedkernel(serial):
+def feedkernel(count, serial):
     """Feed random bytes to /dev/random."""
 
     if os.name != "posix":
         print("This is a Linux-specific command!")
+        sys.exit(1)
+
+    if not 0 <= count <= 255:
+        print(f"Number of bytes must be between 0 and 255, you passed {count}")
         sys.exit(1)
 
     p = solo.client.find(serial)
@@ -72,15 +77,33 @@ def feedkernel(serial):
     entropy_info_file = "/proc/sys/kernel/random/entropy_avail"
     print(f"Entropy before: 0x{open(entropy_info_file).read().strip()}")
 
-    r = p.get_rng(32)
+    r = p.get_rng(count)
 
-    # double-check:
-    # typedef struct {
-    #     int bit_count;               /* number of bits of entropy in data */
-    #     int byte_count;              /* number of bytes of data in array */
-    #     unsigned char buf[BUFSIZ];
-    # } entropy_t;
-    t = struct.pack("ii32s", 8*16, 32, r)
+    # man 4 random
+
+    # RNDADDENTROPY
+    #       Add some additional entropy to the input pool, incrementing the
+    #       entropy count. This differs from writing to /dev/random or
+    #       /dev/urandom, which only adds some data but does not increment the
+    #       entropy count. The following structure is used:
+
+    #           struct rand_pool_info {
+    #               int    entropy_count;
+    #               int    buf_size;
+    #               __u32  buf[0];
+    #           };
+
+    #       Here entropy_count is the value added to (or subtracted from) the
+    #       entropy count, and buf is the buffer of size buf_size which gets
+    #       added to the entropy pool.
+
+    entropy_bits_per_byte = 2  # maximum 8, tend to be pessimistic
+    t = struct.pack(
+        f"ii{count}s",
+        count * entropy_bits_per_byte,
+        count,
+        r,
+    )
 
     with open("/dev/random", mode='wb') as fh:
         res = fcntl.ioctl(fh, RNDADDENTROPY, t)


### PR DESCRIPTION
Thanks for the idea, @manuel-domke!

Example usage: `sudo ALLOW_ROOT= venv/bin/solo key rng feedkernel --count 123`