### PR TITLE
Fido2 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
   "click >= 7.0",
   "cryptography",
   "ecdsa",
-  "fido2",
+  "fido2 == 0.6.0",
   "intelhex",
   "pyserial",
   "pyusb",

--- a/solo/client.py
+++ b/solo/client.py
@@ -104,7 +104,11 @@ class SoloClient:
 
         self.ctap1 = CTAP1(dev)
         self.ctap2 = CTAP2(dev)
-        self.client = Fido2Client(dev, self.origin)
+        try:
+            self.client = Fido2Client(dev, self.origin)
+        except CtapError:
+            print("Not using FIDO2 interface.")
+            self.client = None
 
         if self.exchange == self.exchange_hid:
             self.send_data_hid(CTAPHID.INIT, "\x11\x11\x11\x11\x11\x11\x11\x11")


### PR DESCRIPTION
When new people install `solo-python`, they will also install the recently published `0.6.0 fido2` lib, which has new behavior.  When instantiating a  `Fido2Client` class, it will automatically send a `GetInfo` command, which will fail on any device not supporting a FIDO2 interface.  So this breaks our bootloader update since it only supports U2F.

I patched a fix and pinned the `fido2` version to be `0.6.0`.