### PR TITLE
Allow to specify end app page in the signature making

### DIFF
--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -103,7 +103,8 @@ solo_cli.add_command(sign)
 @click.option("--attestation-key", help="attestation key in hex")
 @click.argument("input_hex_files", nargs=-1)
 @click.argument("output_hex_file")
-def mergehex(attestation_key, input_hex_files, output_hex_file):
+@click.option("--end_page", help="Set APPLICATION_END_PAGE. Should be in sync with firmware settings.", default=20, type=int)
+def mergehex(attestation_key, input_hex_files, output_hex_file, end_page):
     """Merges hex files, and patches in the attestation key.
 
     \b
@@ -111,7 +112,7 @@ def mergehex(attestation_key, input_hex_files, output_hex_file):
     Note that later hex files replace data of earlier ones, if they overlap.
     """
     solo.operations.mergehex(
-        input_hex_files, output_hex_file, attestation_key=attestation_key
+        input_hex_files, output_hex_file, attestation_key=attestation_key, APPLICATION_END_PAGE=end_page
     )
 
 

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -86,10 +86,11 @@ solo_cli.add_command(genkey)
 @click.argument("verifying-key")
 @click.argument("app-hex")
 @click.argument("output-json")
-def sign(verifying_key, app_hex, output_json):
+@click.option("--end_page", help="Set APPLICATION_END_PAGE. Should be in sync with firmware settings.", default=20, type=int)
+def sign(verifying_key, app_hex, output_json, end_page):
     """Signs a firmware hex file, outputs a .json file that can be used for signed update."""
 
-    msg = solo.operations.sign_firmware(verifying_key, app_hex)
+    msg = solo.operations.sign_firmware(verifying_key, app_hex, APPLICATION_END_PAGE=end_page)
     print("Saving signed firmware to", output_json)
     with open(output_json, "wb+") as fh:
         fh.write(json.dumps(msg).encode())

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -92,7 +92,7 @@ def mergehex(input_hex_files, output_hex_file, attestation_key=None):
     first.tofile(output_hex_file, format="hex")
 
 
-def sign_firmware(sk_name, hex_file):
+def sign_firmware(sk_name, hex_file, APPLICATION_END_PAGE = 20):
     # Maybe this is not the optimal module...
 
     import base64
@@ -112,7 +112,6 @@ def sign_firmware(sk_name, hex_file):
     # TODO put this somewhere else.
     START = ih.segments()[0][0]
     # keep in sync with targets/stm32l432/src/memory_layout.h
-    APPLICATION_END_PAGE = 20
     PAGES = 128
     PAGE_SIZE = 2048
     END = (0x08000000 + ((PAGES - APPLICATION_END_PAGE) * PAGE_SIZE)) - 8

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -111,7 +111,7 @@ def sign_firmware(sk_name, hex_file):
     # start of firmware and the size of the flash region allocated for it.
     # TODO put this somewhere else.
     START = ih.segments()[0][0]
-    END = (0x08000000 + ((128 - 19) * 2048)) - 8
+    END = (0x08000000 + ((128 - 20) * 2048)) - 8
 
     ih = IntelHex(hex_file)
     # segs = ih.segments()

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -111,7 +111,11 @@ def sign_firmware(sk_name, hex_file):
     # start of firmware and the size of the flash region allocated for it.
     # TODO put this somewhere else.
     START = ih.segments()[0][0]
-    END = (0x08000000 + ((128 - 20) * 2048)) - 8
+    # keep in sync with targets/stm32l432/src/memory_layout.h
+    APPLICATION_END_PAGE = 20
+    PAGES = 128
+    PAGE_SIZE = 2048
+    END = (0x08000000 + ((PAGES - APPLICATION_END_PAGE) * PAGE_SIZE)) - 8
 
     ih = IntelHex(hex_file)
     # segs = ih.segments()

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -37,7 +37,7 @@ def genkey(output_pem_file, input_seed_file=None):
     return vk
 
 
-def mergehex(input_hex_files, output_hex_file, attestation_key=None):
+def mergehex(input_hex_files, output_hex_file, attestation_key=None, APPLICATION_END_PAGE=20):
     """Merges hex files, and patches in the attestation key.
 
     If no attestation key is passed, uses default Solo Hacker one.
@@ -56,10 +56,11 @@ def mergehex(input_hex_files, output_hex_file, attestation_key=None):
         return 0x08000000 + num * 2048
 
     PAGES = 128
-    APPLICATION_END_PAGE = PAGES - 19
+    APPLICATION_END_PAGE = PAGES - APPLICATION_END_PAGE
     AUTH_WORD_ADDR = flash_addr(APPLICATION_END_PAGE) - 8
     ATTEST_ADDR = flash_addr(PAGES - 15)
 
+    print(f'app end page: {APPLICATION_END_PAGE}')
     first = IntelHex(input_hex_files[0])
     for input_hex_file in input_hex_files[1:]:
         print(f"merging {first} with {input_hex_file}")

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -69,16 +69,13 @@ def mergehex(input_hex_files, output_hex_file, attestation_key=None, APPLICATION
     first[flash_addr(APPLICATION_END_PAGE - 1)] = 0x41
     first[flash_addr(APPLICATION_END_PAGE - 1) + 1] = 0x41
 
-    first[AUTH_WORD_ADDR - 4] = 0
-    first[AUTH_WORD_ADDR - 1] = 0
-    first[AUTH_WORD_ADDR - 2] = 0
-    first[AUTH_WORD_ADDR - 3] = 0
-
-    first[AUTH_WORD_ADDR] = 0
+    # authorize boot
+    first[AUTH_WORD_ADDR + 0] = 0
     first[AUTH_WORD_ADDR + 1] = 0
     first[AUTH_WORD_ADDR + 2] = 0
     first[AUTH_WORD_ADDR + 3] = 0
 
+    # make sure bootloader is enabled
     first[AUTH_WORD_ADDR + 4] = 0xFF
     first[AUTH_WORD_ADDR + 5] = 0xFF
     first[AUTH_WORD_ADDR + 6] = 0xFF


### PR DESCRIPTION
Changes required to make successful signature with the new bootloader. Made the end application page argument variable, so both new and old bootloader could work.

Related:
https://github.com/solokeys/solo/pull/238