### PR TITLE
Refactoring the init warnings

### DIFF
--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -20,19 +20,9 @@ from solo.cli.monitor import monitor
 from solo.cli.program import program
 
 from . import _patches  # noqa  (since otherwise "unused")
+from ._warnings import init_checks
 
-if (os.name == "posix") and os.environ.get("ALLOW_ROOT") is None:
-    if os.geteuid() == 0:
-        print("THIS COMMAND SHOULD NOT BE RUN AS ROOT!")
-        print()
-        print(
-            "Please install udev rules and run `solo` as regular user (without sudo)."
-        )
-        print(
-            "We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules"
-        )
-        print()
-        print("For more information, see: https://docs.solokeys.io/solo/udev/")
+init_checks()
 
 
 @click.group()

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -20,7 +20,7 @@ from solo.cli.monitor import monitor
 from solo.cli.program import program
 
 from . import _patches  # noqa  (since otherwise "unused")
-from ._warnings import init_checks
+from ._checks import init_checks
 
 init_checks()
 

--- a/solo/cli/_checks.py
+++ b/solo/cli/_checks.py
@@ -1,0 +1,40 @@
+import ctypes, os, platform
+
+
+LINUX_ROOT_WARNING = """THIS COMMAND SHOULD NOT BE RUN AS ROOT!
+
+Please install udev rules and run `solo` as regular user (without sudo).
+We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules
+
+For more information, see: https://docs.solokeys.io/solo/udev"""
+
+WINDOWS_CTAP_WARNING = """Try running `solo` with administrator privileges!
+FIDO CTAP access is restricted on Windows 10 version 1903 and higher."""
+
+
+def windows_ctap_restriction():
+    win_ver = platform.sys.getwindowsversion()
+    return (
+        # Windows 10 1903 and higher
+        win_ver.major == 10 and
+        win_ver.build >= 18362 and
+        ctypes.windll.shell32.IsUserAnAdmin() != 1
+    )
+
+
+def windows_checks():
+    if windows_ctap_restriction():
+        print(WINDOWS_CTAP_WARNING)
+
+
+def linux_checks():
+    if os.environ.get("ALLOW_ROOT") is None and os.geteuid() == 0:
+        print(LINUX_ROOT_WARNING)
+
+
+def init_checks():
+    os_family = platform.sys.platform
+    if os_family.startswith('linux'):
+        linux_checks()
+    elif os_family.startswith('win32'):
+        windows_checks()

--- a/solo/cli/_checks.py
+++ b/solo/cli/_checks.py
@@ -4,8 +4,6 @@ import ctypes, os, platform
 LINUX_ROOT_WARNING = """THIS COMMAND SHOULD NOT BE RUN AS ROOT!
 
 Please install udev rules and run `solo` as regular user (without sudo).
-We suggest using: https://github.com/solokeys/solo/blob/master/udev/70-solokeys-access.rules
-
 For more information, see: https://docs.solokeys.io/solo/udev"""
 
 WINDOWS_CTAP_WARNING = """Try running `solo` with administrator privileges!


### PR DESCRIPTION
This PR resolves #24 by adding warning on Windows 10 1903 and higher for the requirement of administrative privileges. I think that it is a good idea and avoids user confusion - at least until the fido2 library or solo gets proper workaround.

![solo_windows_10_1903_warning](https://user-images.githubusercontent.com/1278836/68548835-e1e76600-03f9-11ea-9591-968b39a904b2.png)

Together with the Windows warning, I did refactoring for the Linux root warning as well.