### PR TITLE
Ensure compatibility with python-fido2 0.8 (fixes #49)

### DIFF
--- a/solo/solotool.py
+++ b/solo/solotool.py
@@ -36,7 +36,6 @@ from fido2.ctap import CtapError
 from fido2.ctap1 import CTAP1, ApduError
 from fido2.ctap2 import CTAP2
 from fido2.hid import CTAPHID, CtapHidDevice
-from fido2.utils import Timeout
 from intelhex import IntelHex
 
 import solo


### PR DESCRIPTION
The Timeout has been removed from python-fido2 in version 0.8.