### PR TITLE
use base64 credentials instead of hex

### DIFF
--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -115,6 +115,7 @@ def feedkernel(count, serial):
     "--host", help="Relying party's host", default="solokeys.dev", show_default=True
 )
 @click.option("--user", help="User ID", default="they", show_default=True)
+@click.option("--pin", help="PIN", default=None)
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
@@ -124,16 +125,22 @@ def feedkernel(count, serial):
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-def make_credential(serial, host, user, udp, prompt):
+def make_credential(serial, host, user, udp, prompt, pin):
     """Generate a credential.
 
     Pass `--prompt ""` to output only the `credential_id` as hex.
     """
 
     import solo.hmac_secret
+    
+    #check for PIN
+    if not pin:
+        pin = getpass.getpass("PIN (leave empty for no PIN: ")
+    if not pin:
+        pin = None
 
     solo.hmac_secret.make_credential(
-        host=host, user_id=user, serial=serial, output=True, prompt=prompt, udp=udp
+        host=host, user_id=user, serial=serial, output=True, prompt=prompt, udp=udp, pin=pin
     )
 
 
@@ -141,6 +148,7 @@ def make_credential(serial, host, user, udp, prompt):
 @click.option("-s", "--serial", help="Serial number of Solo use")
 @click.option("--host", help="Relying party's host", default="solokeys.dev")
 @click.option("--user", help="User ID", default="they")
+@click.option("--pin", help="PIN", default=None)
 @click.option(
     "--udp", is_flag=True, default=False, help="Communicate over UDP with software key"
 )
@@ -152,7 +160,7 @@ def make_credential(serial, host, user, udp, prompt):
 )
 @click.argument("credential-id")
 @click.argument("challenge")
-def challenge_response(serial, host, user, prompt, credential_id, challenge, udp):
+def challenge_response(serial, host, user, prompt, credential_id, challenge, udp, pin):
     """Uses `hmac-secret` to implement a challenge-response mechanism.
 
     We abuse hmac-secret, which gives us `HMAC(K, hash(challenge))`, where `K`
@@ -169,6 +177,12 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
 
     import solo.hmac_secret
 
+    #check for PIN
+    if not pin:
+        pin = getpass.getpass("PIN (leave empty for no PIN: ")
+    if not pin:
+        pin = None    
+
     solo.hmac_secret.simple_secret(
         credential_id,
         challenge,
@@ -178,6 +192,7 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
         prompt=prompt,
         output=True,
         udp=udp,
+        pin=pin,
     )
 
 

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -132,7 +132,7 @@ def make_credential(serial, host, user, udp, prompt, pin):
     """
 
     import solo.hmac_secret
-    
+
     #check for PIN
     if not pin:
         pin = getpass.getpass("PIN (leave empty for no PIN: ")
@@ -181,7 +181,7 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
     if not pin:
         pin = getpass.getpass("PIN (leave empty for no PIN: ")
     if not pin:
-        pin = None    
+        pin = None
 
     solo.hmac_secret.simple_secret(
         credential_id,

--- a/solo/hmac_secret.py
+++ b/solo/hmac_secret.py
@@ -9,7 +9,8 @@
 #
 # isort:skip_file
 
-
+import re
+import base64
 import binascii
 import hashlib
 import secrets
@@ -60,7 +61,7 @@ def make_credential(
     credential = attestation_object.auth_data.credential_data
     credential_id = credential.credential_id
     if output:
-        print(credential_id.hex())
+        print(base64.b64encode(credential_id).decode('ascii'))
 
     return credential_id
 
@@ -86,7 +87,15 @@ def simple_secret(
     client.origin = f"https://{client.host}"
     client.user_id = user_id
     # user = {"id": user_id, "name": "A. User"}
-    credential_id = binascii.a2b_hex(credential_id)
+    
+    #check for even number of hex characters (case-insensitive)
+    pattern = re.compile("^([A-Fa-f0-9]{2})+$")
+    if pattern.match(credential_id) is not None:
+        print("using hex decoding:")
+        credential_id = binascii.a2b_hex(credential_id)
+    else:
+        print("non-hex characters found, trying base64 instead")
+        credential_id = base64.b64decode(credential_id)
 
     allow_list = [{"type": "public-key", "id": credential_id}]
 


### PR DESCRIPTION
generally base64 is used for credentials rather than hex, so using that might be useful.

on the other hand hex is still compatible as input for challenge-response.

the 2 commits with PIN are unrelated and not supposed to be here