### PR TITLE
Add serial number to linux device descriptor when parsing uevent files

### DIFF
--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -101,23 +101,3 @@ if sys.platform.startswith("darwin"):
         return descriptors
 
     fido2._pyu2f.macos.MacOsHidDevice.Enumerate = newEnumerate
-
-
-## Linux
-if sys.platform.startswith("linux"):
-    import fido2._pyu2f.linux
-
-    oldnewParseUevent = fido2._pyu2f.linux.ParseUevent
-
-    def newParseUevent(uevent, desc):
-        oldnewParseUevent(uevent, desc)
-        lines = uevent.split(b"\n")
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            k, v = line.split(b"=")
-            if k == b"HID_UNIQ":
-                desc.serial_number = v.decode("utf8")
-
-    fido2._pyu2f.linux.ParseUevent = newParseUevent

--- a/solo/client.py
+++ b/solo/client.py
@@ -29,6 +29,7 @@ from intelhex import IntelHex
 import solo.exceptions
 from solo import helpers
 from solo.commands import SoloBootloader, SoloExtension
+import solo.fido2
 
 
 def find(solo_serial=None, retries=5, raw_device=None, udp=False):


### PR DESCRIPTION
I wanted to get the solo key's serial number from python but noticed that it was only available on the CLI interface. This PR refactors the code so that the fix is applied universally when a device descriptor is created instead of only when a command is given from the cli interface.

I have more details about this in issue #80 Getting Serial number from solo library.
