### PR TITLE
Challenge Response prompt typo fix.

### DIFF
--- a/solo/hmac_secret.py
+++ b/solo/hmac_secret.py
@@ -72,7 +72,7 @@ def simple_secret(
     user_id="they",
     serial=None,
     pin=None,
-    prompt="Touch your authenticator to generate a reponse...",
+    prompt="Touch your authenticator to generate a response...",
     output=True,
     udp=False,
 ):


### PR DESCRIPTION
Small typo I noticed at the `solo key challenge-response` command while looking at #82 