### PR TITLE
Add vendor command for programming the keyboard interface

### DIFF
--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -465,6 +465,19 @@ def ping(serial, udp, ping_data):
 
 @click.command()
 @click.option("-s", "--serial", help="Serial number of Solo to use")
+@click.argument("sequence")
+def keyboard(serial, sequence):
+    """Program the specified key sequence to Solo"""
+
+    dev = solo.client.find(serial)
+    buf = sequence.encode("ascii")
+    if len(buf) > 64:
+        print("Keyboard sequence cannot exceed 64 bytes")
+    else:
+        dev.program_kbd(buf)
+
+@click.command()
+@click.option("-s", "--serial", help="Serial number of Solo to use")
 def disable_updates(serial):
     """Permanently disable firmware updates on Solo.  Cannot be undone.  Solo must be in bootloader mode."""
 
@@ -497,3 +510,4 @@ key.add_command(verify)
 key.add_command(wink)
 key.add_command(disable_updates)
 key.add_command(ping)
+key.add_command(keyboard)

--- a/solo/client.py
+++ b/solo/client.py
@@ -316,6 +316,9 @@ class SoloClient:
         self.exchange(SoloBootloader.reboot)
         return True
 
+    def program_kbd(self, cmd):
+        return self.ctap2.send_cbor(0x51, cmd)
+
     def program_file(self, name):
         def parseField(f):
             return base64.b64decode(helpers.from_websafe(f).encode())


### PR DESCRIPTION
The new command can program a key sequence that will be emitted from the
Solo keyboard interface when the hardware key is pressed.
The command value is 0x51 with a single argument which is a byte string
(up to 64 bytes).