### PR TITLE
DFU mode: improve programming robustness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.27] - 2021-01-20
 - pin fido2 dep to 0.8 series @uli-heller
+- improve programming robustness @enrikb
 
 ## [0.0.26] - 2020-07-17
 - fix bungled reference to `STABLE_VERSION` file


### PR DESCRIPTION
dfu.get_status() might return usb.core.USBError with errno == EPIPE,
when called in quick succession. This is the case when called from
dfu.block_on_state(). The next call usually works.

This change tries to catch this specific error and just re-tries in case
it happens.

Without this change, the error (and programming abort) might get
undetected, as click catches IOerror/EPIPE silently. This has
significant potential to brick a device.

This change addresses issue #97.