### PR TITLE
Bugfix: make monitor reconnect work

### DIFF
--- a/solo/cli/monitor.py
+++ b/solo/cli/monitor.py
@@ -23,7 +23,7 @@ def monitor(serial_port):
     Automatically reconnects. Baud rate is 115200.
     """
 
-    ser = serial.Serial(serial_port, 115200, timeout=0.05)
+    ser = None
 
     def reconnect():
         while True:
@@ -36,10 +36,14 @@ def monitor(serial_port):
 
     while True:
         try:
+            if ser is None:
+                ser = serial.Serial(serial_port, 115200, timeout=0.05)
             data = ser.read(1)
+            sys.stdout.buffer.write(data)
+            sys.stdout.flush()
         except serial.SerialException:
-            print("reconnecting...")
+            if ser is not None:
+                ser.close()
+            print(f"reconnecting {serial_port}...")
             ser = reconnect()
             print("done")
-        sys.stdout.buffer.write(data)
-        sys.stdout.flush()


### PR DESCRIPTION
On my Linux system (and maybe others as well), /dev/ttyACM0 is only
created after the Solo key is inserted. If you try to 'monitor' before
inserting, it will fail because the device node does not yet exist. Of
course one can use debug-2 to stall the Solo key until monitor opens the
serial device. However, this has the side effect of making the Solo key
not work without a running monitor.

Second, if you disconnect the Solo key, 'monitor' tries to reconnect,
but does not close the serial device before. The device node might be
deleted, but the minor number is still in use. Therefore, on next
connect e.g. /dev/ttyACM1 will be used and the reconnection will fail.

This change

1. enters reconnect mode also when the device node does not exist
initially

2. closes the device before entering reconnect mode if it was opened
before

(This has only been tested on Linux, namely Ubuntu 20.04.)