### PR TITLE
Change Makefile to work with isort version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- bumped isort version to >=5.0.0 and changed Makefile accordingly, see [Upgrading isort to 5.0.0](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/)
 
 ## [0.0.25] - 2020-07-17
 - fix bungled reference to `STABLE_VERSION` file

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init: update-venv
 # ensure this passes before commiting
 check: lint
 	black --check solo/
-	isort --check-only --recursive solo/
+	isort --profile black --check-only solo/
 
 # automatic code fixes
 fix: black isort
@@ -15,7 +15,7 @@ black:
 	black solo/
 
 isort:
-	isort -y --recursive solo/
+	isort --profile black solo/
 
 lint:
 	flake8 solo/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ black
 flake8
 flit
 ipython
-isort
+isort>=5.0.0
 

--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -16,8 +16,8 @@ if sys.platform.startswith("win32"):
     import fido2._pyu2f.windows
 
     oldDevAttrFunc = fido2._pyu2f.windows.FillDeviceAttributes
-    from ctypes import wintypes
     import ctypes
+    from ctypes import wintypes
 
     fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.restype = wintypes.BOOLEAN
     fido2._pyu2f.windows.hid.HidD_GetSerialNumberString.argtypes = [
@@ -43,18 +43,18 @@ if sys.platform.startswith("darwin"):
     import fido2._pyu2f.macos
     from fido2._pyu2f import base
     from fido2._pyu2f.macos import (
-        iokit,
+        HID_DEVICE_PROPERTY_PRIMARY_USAGE,
+        HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE,
+        HID_DEVICE_PROPERTY_PRODUCT,
+        HID_DEVICE_PROPERTY_PRODUCT_ID,
+        HID_DEVICE_PROPERTY_REPORT_ID,
+        HID_DEVICE_PROPERTY_VENDOR_ID,
         IO_HID_DEVICE_REF,
         GetDeviceIntProperty,
         GetDevicePath,
         GetDeviceStringProperty,
-        HID_DEVICE_PROPERTY_VENDOR_ID,
-        HID_DEVICE_PROPERTY_PRODUCT_ID,
-        HID_DEVICE_PROPERTY_PRODUCT,
-        HID_DEVICE_PROPERTY_PRIMARY_USAGE,
-        HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE,
-        HID_DEVICE_PROPERTY_REPORT_ID,
         cf,
+        iokit,
     )
 
     HID_DEVICE_PROPERTY_SERIAL_NUMBER = b"SerialNumber"

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -82,8 +82,8 @@ def feedkernel(count, serial):
 
     p = solo.client.find(serial)
 
-    import struct
     import fcntl
+    import struct
 
     RNDADDENTROPY = 0x40085203
 

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -57,8 +57,8 @@ def dfu(serial, connect_attempts, detach, dry_run, firmware):
 
     import time
 
-    from intelhex import IntelHex
     import usb.core
+    from intelhex import IntelHex
 
     dfu = solo.dfu.find(serial, attempts=connect_attempts)
 

--- a/solo/client.py
+++ b/solo/client.py
@@ -343,8 +343,8 @@ class SoloClient:
             return base64.b64decode(helpers.from_websafe(f).encode())
 
         def isCorrectVersion(current, target):
-            """ current is tuple (x,y,z).  target is string '>=x.y.z'.
-                Return True if current satisfies the target expression.
+            """current is tuple (x,y,z).  target is string '>=x.y.z'.
+            Return True if current satisfies the target expression.
             """
             if "=" in target:
                 target = target.split("=")

--- a/solo/client.py
+++ b/solo/client.py
@@ -70,24 +70,24 @@ def find_all():
 
 
 class SoloClient:
-    def __init__(self,):
+    def __init__(self):
         self.origin = "https://example.org"
         self.host = "example.org"
         self.user_id = b"they"
         self.exchange = self.exchange_hid
         self.do_reboot = True
 
-    def use_u2f(self,):
+    def use_u2f(self):
         self.exchange = self.exchange_u2f
 
-    def use_hid(self,):
+    def use_hid(self):
         self.exchange = self.exchange_hid
 
     def set_reboot(self, val):
         """ option to reboot after programming """
         self.do_reboot = val
 
-    def reboot(self,):
+    def reboot(self):
         """ option to reboot after programming """
         try:
             self.exchange(SoloBootloader.reboot)
@@ -183,13 +183,13 @@ class SoloClient:
 
         return res.signature[1:]
 
-    def bootloader_version(self,):
+    def bootloader_version(self):
         data = self.exchange(SoloBootloader.version)
         if len(data) > 2:
             return (data[0], data[1], data[2])
         return (0, 0, data[0])
 
-    def solo_version(self,):
+    def solo_version(self):
         try:
             return self.send_data_hid(0x61, b"")
         except CtapError:
@@ -211,13 +211,13 @@ class SoloClient:
         """
         self.exchange(SoloBootloader.done, 0, sig)
 
-    def wink(self,):
+    def wink(self):
         self.send_data_hid(CTAPHID.WINK, b"")
 
     def ping(self, data="pong"):
         return self.send_data_hid(CTAPHID.PING, data)
 
-    def reset(self,):
+    def reset(self):
         self.ctap2.reset()
 
     def change_pin(self, old_pin, new_pin):
@@ -253,7 +253,7 @@ class SoloClient:
         pin_protocol = 1
         return CredentialManagement(self.ctap2, pin_protocol, token)
 
-    def enter_solo_bootloader(self,):
+    def enter_solo_bootloader(self):
         """
         If solo is configured as solo hacker or something similar,
         this command will tell the token to boot directly to the bootloader
@@ -277,7 +277,7 @@ class SoloClient:
             else:
                 raise (e)
 
-    def is_solo_bootloader(self,):
+    def is_solo_bootloader(self):
         try:
             self.bootloader_version()
             return True
@@ -288,7 +288,7 @@ class SoloClient:
                 raise (e)
         return False
 
-    def enter_st_dfu(self,):
+    def enter_st_dfu(self):
         """
         If solo is configured as solo hacker or something similar,
         this command will tell the token to boot directly to the st DFU
@@ -302,7 +302,7 @@ class SoloClient:
         else:
             self.send_only_hid(SoloBootloader.HIDCommandEnterSTBoot, "")
 
-    def disable_solo_bootloader(self,):
+    def disable_solo_bootloader(self):
         """
         Disables the Solo bootloader.  Only do this if you want to void the possibility
         of any updates.

--- a/solo/dfu.py
+++ b/solo/dfu.py
@@ -55,7 +55,7 @@ def hot_patch_windows_libusb():
 
 
 class DFUDevice:
-    def __init__(self,):
+    def __init__(self):
         pass
 
     @staticmethod
@@ -129,24 +129,24 @@ class DFUDevice:
                     self.intNum = intf.bInterfaceNumber
                     # return self.dev
 
-    def init(self,):
+    def init(self):
         if self.state() == DFU.state.ERROR:
             self.clear_status()
 
-    def close(self,):
+    def close(self):
         pass
 
-    def get_status(self,):
+    def get_status(self):
         # bmReqType, bmReq, wValue, wIndex, data/size
         s = self.dev.ctrl_transfer(
             DFU.type.RECEIVE, DFU.bmReq.GETSTATUS, 0, self.intNum, 6
         )
         return DFU.status(s)
 
-    def state(self,):
+    def state(self):
         return self.get_status().state
 
-    def clear_status(self,):
+    def clear_status(self):
         # bmReqType, bmReq, wValue, wIndex, data/size
         self.dev.ctrl_transfer(DFU.type.SEND, DFU.bmReq.CLRSTATUS, 0, self.intNum, None)
 
@@ -212,7 +212,7 @@ class DFUDevice:
             time.sleep(s.timeout / 1000.0)
             s = self.get_status()
 
-    def read_option_bytes(self,):
+    def read_option_bytes(self):
         ptr = 0x1FFF7800  # option byte address for STM32l432
         self.set_addr(ptr)
         self.block_on_state(DFU.state.DOWNLOAD_BUSY)
@@ -227,7 +227,7 @@ class DFUDevice:
         except OSError:
             print("Warning: OSError with write_page")
 
-    def prepare_options_bytes_detach(self,):
+    def prepare_options_bytes_detach(self):
 
         # Necessary to prevent future errors...
         m = self.read_mem(0, 16)
@@ -245,7 +245,7 @@ class DFUDevice:
             m = struct.pack("<L", op) + m[4:]
             self.write_option_bytes(m)
 
-    def detach(self,):
+    def detach(self):
         if self.state() not in (DFU.state.IDLE, DFU.state.DOWNLOAD_IDLE):
             self.clear_status()
             self.clear_status()

--- a/solo/operations.py
+++ b/solo/operations.py
@@ -16,7 +16,7 @@ from solo import helpers
 
 
 def genkey(output_pem_file, input_seed_file=None):
-    from ecdsa import SigningKey, NIST256p
+    from ecdsa import NIST256p, SigningKey
     from ecdsa.util import randrange_from_seed__trytryagain
 
     if input_seed_file is not None:
@@ -191,10 +191,10 @@ def sign_firmware_for_version(sk_name, hex_file, APPLICATION_END_PAGE):
     # Maybe this is not the optimal module...
 
     import base64
-
     import binascii
-    from ecdsa import SigningKey
     from hashlib import sha256
+
+    from ecdsa import SigningKey
     from intelhex import IntelHex
 
     sk = SigningKey.from_pem(open(sk_name).read())


### PR DESCRIPTION
Just noticed that some of the make targets did not work well on a fresh checkout and init.
Seems to be related to `isort` version 5 differences.
This PR tries to fix the inconsistencies.