### PR TITLE
Allow interactive PIN entry for `solo key verify`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.27] - 2021-01-20
 - pin fido2 dep to 0.8 series @uli-heller
 - improve programming robustness @enrikb
+- prompt for PIN in `solo key verify`, if needed @enrikb
 
 ## [0.0.26] - 2020-07-17
 - fix bungled reference to `STABLE_VERSION` file

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -347,14 +347,24 @@ def set_pin(serial):
 def verify(pin, serial, udp):
     """Verify key is valid Solo Secure or Solo Hacker."""
 
+    key = solo.client.find(serial, udp=udp)
+
+    if (
+        key.client
+        and ("clientPin" in key.client.info.options)
+        and key.client.info.options["clientPin"]
+        and not pin
+    ):
+        pin = getpass.getpass("PIN: ")
+
     # Any longer and this needs to go in a submodule
     print("Please press the button on your Solo key")
     try:
-        cert = solo.client.find(serial, udp=udp).make_credential(pin=pin)
+        cert = key.make_credential(pin=pin)
     except Fido2ClientError as e:
         cause = str(e.cause)
         if "PIN required" in cause:
-            print("Your key has a PIN set. Please pass it using `--pin <your PIN>`")
+            print("Your key has a PIN set but none was provided.")
             sys.exit(1)
         # error 0x31
         if "PIN_INVALID" in cause:


### PR DESCRIPTION
While still allowing to pass `--pin <pin>` like some of the other commands, do no longer suggest it.

The solution is a bit hacky, calling `verify` recursively a second time iff a PIN is required but was not set before.

The 'Please press the button on your Solo key' is also not very consistently repeated, but it is also output a little inconsistently before this change.