### PR TITLE
Wait that udev has set owner and group

### DIFF
--- a/solo/cli/update.py
+++ b/solo/cli/update.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import sys
 import tempfile
-import time
 
 import click
 import requests
@@ -184,7 +183,6 @@ def update(serial, yes, local_firmware_server, alpha):
         if not solo_client.is_solo_bootloader():
             print("Switching into bootloader mode...")
             solo_client.enter_bootloader_or_die()
-            time.sleep(0.5)
             solo_client = solo.client.find(serial)
 
         solo_client.set_reboot(False)


### PR DESCRIPTION
Udev rules take some time to be applied, then `fido2` lib fails to open the solokey since the group of the device hasn't been set:

    $ solo key update
    Wrote temporary copy of firmware-4.1.1.json to /tmp/tmpa67i8qxc.json
    sha256sums coincide: 45e7071107fa5acb494e4c5d4831344dd531b1a537a230a6157f4f71dba87e2c
    Switching into bootloader mode...
    error:
    problem flashing firmware!
    no Solo found

With this patch, the key is found after switching into bootloader mode but the key doesn't switch to bootloader mode, which is another issue. At least the messages are improved:

    $ solo key update
    Wrote temporary copy of firmware-4.1.1.json to /tmp/tmpvwzbaat0.json
    sha256sums coincide: 45e7071107fa5acb494e4c5d4831344dd531b1a537a230a6157f4f71dba87e2c
    Switching into bootloader mode...
    Wait for device '205C36995548'...
    using signature version <=2.5.3
    erasing firmware...
    Could not switch into bootloader mode.
    Please put key into bootloader mode:
    1. Unplug key
    2. While holding button, plug in key for 2s

Could be related to  #113.