### PR TITLE
Ignore ValueError from fido2 ParseUevent.

### DIFF
--- a/solo/cli/_patches.py
+++ b/solo/cli/_patches.py
@@ -110,13 +110,19 @@ if sys.platform.startswith("linux"):
     oldnewParseUevent = fido2._pyu2f.linux.ParseUevent
 
     def newParseUevent(uevent, desc):
-        oldnewParseUevent(uevent, desc)
+        try:
+            oldnewParseUevent(uevent, desc)
+        except ValueError:
+            pass
         lines = uevent.split(b"\n")
         for line in lines:
             line = line.strip()
             if not line:
                 continue
-            k, v = line.split(b"=")
+            try:
+                k, v = line.split(b"=")
+            except ValueError:
+                continue
             if k == b"HID_UNIQ":
                 desc.serial_number = v.decode("utf8")
 


### PR DESCRIPTION
As reported in #117, there can be lines in Linux hidraw sysfs files for certain devices (maybe broken? or is it a kernel issue?) missing an '=' sign.

The fido2 ParseUevent() method fails if it hits a line missing the '=' in the uevent sysfs file and `solo` aborts due to an unhandled exception.

As solo-python already live patches the method, add a try-except to the call of the original method and ignore the ValueError thrown in such a situation. The same is applied to the split() call in this method.

Closes #117.