### PR TITLE
Add pin argument to make-credential

### DIFF
--- a/solo/hmac_secret.py
+++ b/solo/hmac_secret.py
@@ -49,7 +49,8 @@ def make_credential(
                 {"type": "public-key", "alg": -7},
             ],
             "extensions": {"hmacCreateSecret": True},
-        }
+        },
+        pin=pin,
     ).attestation_object
 
     credential = attestation_object.auth_data.credential_data


### PR DESCRIPTION
This fixes an issue where a device with a set pin can not run the
make-credential command as the pin is not forwarded to fido2.