### PR TITLE
Add support for EdDSA/Minisign signatures to sign-hash/sign-file, also add support for choosing credential algorithm to make-credential

### DIFF
--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -122,6 +122,17 @@ def feedkernel(count, serial):
 
 
 @click.command()
+def list_algorithms():
+    """Display algorithms supported by client.
+
+    These can be passed to `solo key make-credential`.
+    """
+
+    alg_names = (fido2.cose.CoseKey.for_alg(alg).__name__ for alg in fido2.cose.CoseKey.supported_algorithms())
+    print(f"Supported algorithms: {', '.join(alg_names)}")
+
+
+@click.command()
 @click.option("-s", "--serial", help="Serial number of Solo use")
 @click.option(
     "--host", help="Relying party's host", default="solokeys.dev", show_default=True
@@ -137,7 +148,8 @@ def feedkernel(count, serial):
     default="Touch your authenticator to generate a credential...",
     show_default=True,
 )
-@click.option("--alg", default="EdDSA,ES256", help="Algorithm(s) for key, separated by ',', in order of preference")
+@click.option("--alg", default="EdDSA,ES256", show_default=True,
+              help="Algorithm(s) for key, separated by ',', in order of preference")
 @click.option("--no-pubkey", is_flag=True, default=False, help="Do not display public key")
 @click.option("--minisign", is_flag=True, default=False, help="Display public key in Minisign-compatible format")
 @click.option("--key-file", default=None, help="File to store public key (use with --minisign)")
@@ -145,7 +157,8 @@ def feedkernel(count, serial):
                                              " [default: <hash of credential ID>]")
 @click.option("--untrusted-comment", default=None,
               help="Untrusted comment to write to public key file (use with --key-file) [default: <key ID>]")
-def make_credential(serial, host, user, udp, prompt, pin, alg, no_pubkey, minisign, key_file, key_id, untrusted_comment):
+def make_credential(serial, host, user, udp, prompt, pin,
+                    alg, no_pubkey, minisign, key_file, key_id, untrusted_comment):
     """Generate a credential.
 
     Pass `--prompt "" --no-pubkey` to output only the `credential_id` as hex.
@@ -775,6 +788,7 @@ key.add_command(rng)
 rng.add_command(hexbytes)
 rng.add_command(raw)
 rng.add_command(feedkernel)
+key.add_command(list_algorithms)
 key.add_command(make_credential)
 key.add_command(challenge_response)
 key.add_command(reset)


### PR DESCRIPTION
This adds support for EdDSA pre-hashed signatures to `sign-file` (solokeys/solo#397), possibly including a trusted comment according to [Minisign](https://jedisct1.github.io/minisign/).

New `sign-file` flags:
```
  --minisign                Use Minisign-compatible signatures (pre-hashed)
  --sig-file TEXT           Destination file for signature
                            (<filename>.(mini)sig if empty)
  --trusted-comment TEXT    Trusted comment included in global signature
                            (combine with --minisign) [default: <time and file
                            name, prehashed>]
  --untrusted-comment TEXT  Untrusted comment not included in global signature
                            (combine with --minisign and --sig-file)
                            [default: signature created on solokey]
  --key-id TEXT             Key ID to write to signature file (8 bytes as HEX)
                            (combine with --minisign and --sig-file) [default:
                            <hash of credential ID>]
```

If the `--minisign` flag is passed, the signature will using pre-hashing with Blake2b-512 instead of SHA-256 and the signature file will be a Minisign-compatible signature. The flag can only be used with EdDSA credentials.

To be able to choose the credential type, I added the following flag to `make-credential`:
```
  --alg TEXT                Algorithm(s) for key, separated by ',', in order
                            of preference  [default: EdDSA,ES256]
```

To view supported algorithms, use the new `solo key list-algorithms` command.

`make-credential` now also supports saving Minisign keys for EdDSA credentials, and it prints the public key:
```
  --no-pubkey               Do not display public key
  --minisign                Display public key in Minisign-compatible format
  --key-file TEXT           File to store public key (use with --minisign)
  --key-id TEXT             Key ID to write to key file (8 bytes as HEX) (use
                            with --key-file) [default: <hash of credential ID>]
  --untrusted-comment TEXT  Untrusted comment to write to public key file (use
                            with --key-file) [default: <key ID>]
```

Breaking change: the `credential_id` parameter is now assumed to be a HEX credential, to make it consistent with `make-credential`.

More info, mostly about an earlier version using a FIDO2 extension instead of a custom CTAP command, can be found in solokeys/solo#575.