### PR TITLE
Fix "make init" and "pip install solo1-cli" after upstream fido2 library change

### DIFF
--- a/solo/devices/base.py
+++ b/solo/devices/base.py
@@ -3,7 +3,7 @@ import struct
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from fido2.attestation import Attestation
-from fido2.ctap2 import CTAP2, CredentialManagement
+from fido2.ctap2 import Ctap2, CredentialManagement
 from fido2.hid import CTAPHID
 from fido2.utils import hmac_sha256
 from fido2.webauthn import PublicKeyCredentialCreationOptions
@@ -76,7 +76,7 @@ class SoloClient:
     def reset(
         self,
     ):
-        CTAP2(self.get_current_hid_device()).reset()
+        Ctap2(self.get_current_hid_device()).reset()
 
     def change_pin(self, old_pin, new_pin):
         client = self.get_current_fido_client()
@@ -114,7 +114,7 @@ class SoloClient:
     def cred_mgmt(self, pin):
         client = self.get_current_fido_client()
         token = client.client_pin.get_pin_token(pin)
-        ctap2 = CTAP2(self.get_current_hid_device())
+        ctap2 = Ctap2(self.get_current_hid_device())
         return CredentialManagement(ctap2, client.client_pin.protocol, token)
 
     def enter_solo_bootloader(
@@ -137,11 +137,11 @@ class SoloClient:
         pass
 
     def program_kbd(self, cmd):
-        ctap2 = CTAP2(self.get_current_hid_device())
+        ctap2 = Ctap2(self.get_current_hid_device())
         return ctap2.send_cbor(0x51, cmd)
 
     def sign_hash(self, credential_id, dgst, pin):
-        ctap2 = CTAP2(self.get_current_hid_device())
+        ctap2 = Ctap2(self.get_current_hid_device())
         client = self.get_current_fido_client()
         if pin:
             pin_token = client.client_pin.get_pin_token(pin)

--- a/solo/devices/solo_v1.py
+++ b/solo/devices/solo_v1.py
@@ -8,8 +8,8 @@ from threading import Event
 
 from fido2.client import Fido2Client
 from fido2.ctap import CtapError
-from fido2.ctap1 import CTAP1
-from fido2.ctap2 import CTAP2
+from fido2.ctap1 import Ctap1
+from fido2.ctap2 import Ctap2
 from fido2.hid import CTAPHID, CtapHidDevice
 from intelhex import IntelHex
 
@@ -64,9 +64,9 @@ class Client(SoloClient):
             dev = devices[0]
         self.dev = dev
 
-        self.ctap1 = CTAP1(dev)
+        self.ctap1 = Ctap1(dev)
         try:
-            self.ctap2 = CTAP2(dev)
+            self.ctap2 = Ctap2(dev)
         except CtapError:
             self.ctap2 = None
 

--- a/solo/solotool.py
+++ b/solo/solotool.py
@@ -32,8 +32,8 @@ from cryptography.hazmat.primitives import hashes
 from fido2.attestation import Attestation
 from fido2.client import ClientError, Fido2Client
 from fido2.ctap import CtapError
-from fido2.ctap1 import CTAP1, ApduError
-from fido2.ctap2 import CTAP2
+from fido2.ctap1 import Ctap1, ApduError
+from fido2.ctap2 import Ctap2
 from fido2.hid import CTAPHID, CtapHidDevice
 from intelhex import IntelHex
 


### PR DESCRIPTION
The fido2 library has changed the names of the CTAP1 class to Ctap1 and
the CTAP2 class to Ctap2.  The old names were removed in the most recent version of the fido2 library in the python package index, which breaks installing solo1-cli with pip and breaks running "make init" with the existing solo1-cli repository.

This pull request updates the solo1-cli code to use the new names (which hopefully will be stable now that the fido2 library has reached version 1.0).

Fixes #151 