### PR TITLE
fixed requirement of fido2 until upgrade to fido2 >= 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
   "click >= 7.1",
   "cryptography",
   "ecdsa",
-  "fido2 >= 0.9.1",
+  "fido2 ~= 0.9",
   "intelhex",
   "pyserial",
   "pyusb",


### PR DESCRIPTION
This fixes the current problem with the incompatible fido2-1.0 changes by explicitly requiring fido2 0.9.x
until #152 can get merged.