### PR TITLE
Fix ignoring output option in simple_secret

### DIFF
--- a/solo/hmac_secret.py
+++ b/solo/hmac_secret.py
@@ -104,8 +104,8 @@ def simple_secret(
         pin=pin,
     ).get_response(0)
 
-    output = assertion.extension_results["hmacGetSecret"]["output1"]
+    response = assertion.extension_results["hmacGetSecret"]["output1"]
     if output:
-        print(output.hex())
+        print(response.hex())
 
-    return output
+    return response


### PR DESCRIPTION
The `make_credential` function has an `output` argument, which is supposed to toggle whether the function should print the response or not. However this variable was overwritten inside the function, which is a bug.