### PR TITLE
Use flit_core as build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "solo"


### PR DESCRIPTION
And specify a version range - this should ensure building from source still works (with flit_core 3.x) when 4.x is out with changes.